### PR TITLE
Fixing legend to match the label

### DIFF
--- a/app/logic/map.R
+++ b/app/logic/map.R
@@ -131,9 +131,9 @@ server <- function(id, studies, shp, consts) {
             addLegend(
               position = "bottomleft",
               title = "Evidence",
-              bins = -1:1,
-              values = -1:1,
-              colors = pal(-1:1),
+              bins = 1:-1,
+              values = 1:-1,
+              colors = pal(1:-1),
               labels = c("Positive", "Neutral", "Negative"),
               opacity = 1
             )


### PR DESCRIPTION
## Changes description

- Matching label and values in leaflet legend
- Using the reverse order: positive, neutral, negative